### PR TITLE
Kit 192/cors error fix

### DIFF
--- a/src/main/java/com/se/fileserver/v1/common/infra/web/filter/CorsHeaderFilter.java
+++ b/src/main/java/com/se/fileserver/v1/common/infra/web/filter/CorsHeaderFilter.java
@@ -21,7 +21,8 @@ public class CorsHeaderFilter {
     config.setAllowCredentials(true);
     config.addAllowedOrigin("http://localhost:3000");
     config.addAllowedOrigin("https://localhost:3000");
-    config.addAllowedOrigin(fileDashServerDomain);
+    config.addAllowedOrigin("https://filetest.se-testboard.duckdns.org");
+    config.addAllowedOrigin("");
     config.addAllowedHeader("*");
     config.addAllowedMethod("*");
     source.registerCorsConfiguration("/**", config);

--- a/src/main/java/com/se/fileserver/v1/common/infra/web/filter/CorsHeaderFilter.java
+++ b/src/main/java/com/se/fileserver/v1/common/infra/web/filter/CorsHeaderFilter.java
@@ -20,6 +20,7 @@ public class CorsHeaderFilter {
     CorsConfiguration config = new CorsConfiguration();
     config.setAllowCredentials(true);
     config.addAllowedOrigin("http://localhost:3000");
+    config.addAllowedOrigin("https://localhost:3000");
     config.addAllowedOrigin(fileDashServerDomain);
     config.addAllowedHeader("*");
     config.addAllowedMethod("*");

--- a/src/main/java/com/se/fileserver/v1/common/infra/web/filter/CorsHeaderFilter.java
+++ b/src/main/java/com/se/fileserver/v1/common/infra/web/filter/CorsHeaderFilter.java
@@ -11,6 +11,9 @@ import org.springframework.web.filter.CorsFilter;
 @Configuration
 public class CorsHeaderFilter {
 
+  @Value("${se-file-server.domain}")
+  private String fileServerDomain;
+
   @Value("${se-web-server.file-dash-server-domain}")
   private String fileDashServerDomain;
 
@@ -20,9 +23,8 @@ public class CorsHeaderFilter {
     CorsConfiguration config = new CorsConfiguration();
     config.setAllowCredentials(true);
     config.addAllowedOrigin("http://localhost:3000");
-    config.addAllowedOrigin("https://localhost:3000");
-    config.addAllowedOrigin("https://filetest.se-testboard.duckdns.org");
-    config.addAllowedOrigin("");
+    config.addAllowedOrigin(fileServerDomain);
+    config.addAllowedOrigin(fileDashServerDomain);
     config.addAllowedHeader("*");
     config.addAllowedMethod("*");
     source.registerCorsConfiguration("/**", config);


### PR DESCRIPTION
# Pull Request Check List
- Major Reviewer: @KitTeamSe/be 

## CheckList

- [ ] Unit test coverage
- [ ] Backward compatibility
- [ ] Tested on dev/staging environment
- [ ] Documentation
- [x] Self reviewed

## Context
https로 변경 후 cors 에러가 발생하여, 도메인을 yml파일에서 주입받게 하였습니다.

